### PR TITLE
Environment setup

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -6,6 +6,7 @@ generic-service:
 
   ingress:
     host: supported-accommodation-dev.hmpps.service.justice.gov.uk
+    tlsSecretName: hmpps-supported-accommodation-dev-cert
 
   env:
     ENVIRONMENT: dev

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -13,6 +13,8 @@ generic-service:
     APPROVED_PREMISES_API_URL: "https://approved-premises-api-dev.hmpps.service.justice.gov.uk"
     HMPPS_AUTH_URL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
     TOKEN_VERIFICATION_API_URL: "https://token-verification-api-dev.prison.service.justice.gov.uk"
+  
+  allowlist: null
 
 generic-prometheus-alerts:
   alertSeverity: digital-prison-service-dev


### PR DESCRIPTION
* add `tlsSecretName` to helm dev values
    
This allows the certificate to work

* add `allowlist: null`
    
This will enable non-moj laptops to access the site.