### PR TITLE
upgrade to node 18.16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ parameters:
 
   node-version:
     type: string
-    default: 18.15-browsers
+    default: 18.16-browsers
 
 jobs:
   build:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage: base image
-FROM node:18.15-bullseye-slim as base
+FROM node:18.16-bullseye-slim as base
 
 ARG BUILD_NUMBER=1_0_0
 ARG GIT_REF=not-available


### PR DESCRIPTION
Package.json already referenced using version 18:

```
  "engines": {
    "node": "^18",
```

Now, CircleCI and docker containers will run with version 18.16
[To fix security vulnerability CVE-2022-29458](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-supported-accommodation-ui/60/workflows/ad3d130a-bc4e-40aa-ac9d-a40fba81cddc/jobs/216)

## old image

```
$ docker build . -t test-16
$ docker run --rm -v trivy-cache:/root/.cache/ -v /var/run/docker.sock:/var/run/docker.sock aquasec/trivy:latest image --exit-code 100 --no-progress --severity HIGH,CRITICAL --ignore-unfixed --skip-dirs /usr/local/lib/node_modules/npm --skip-files /app/agent.jar test-16
2023-05-10T13:59:37.632Z        INFO    Vulnerability scanning is enabled
2023-05-10T13:59:37.632Z        INFO    Secret scanning is enabled
2023-05-10T13:59:37.632Z        INFO    If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2023-05-10T13:59:37.632Z        INFO    Please see also https://aquasecurity.github.io/trivy/v0.41/docs/secret/scanning/#recommendation for faster secret detection
2023-05-10T13:59:41.679Z        INFO    Detected OS: debian
2023-05-10T13:59:41.679Z        INFO    Detecting Debian vulnerabilities...
2023-05-10T13:59:41.684Z        INFO    Number of language-specific files: 1
2023-05-10T13:59:41.684Z        INFO    Detecting node-pkg vulnerabilities...

test-18 (debian 11.6)
=====================
Total: 3 (HIGH: 3, CRITICAL: 0)

┌──────────────┬────────────────┬──────────┬───────────────────┬────────────────────────┬────────────────────────────────────────────┐
│   Library    │ Vulnerability  │ Severity │ Installed Version │     Fixed Version      │                   Title                    │
├──────────────┼────────────────┼──────────┼───────────────────┼────────────────────────┼────────────────────────────────────────────┤
│ libtinfo6    │ CVE-2022-29458 │ HIGH     │ 6.2+20201114-2    │ 6.2+20201114-2+deb11u1 │ ncurses: segfaulting OOB read              │
│              │                │          │                   │                        │ https://avd.aquasec.com/nvd/cve-2022-29458 │
├──────────────┤                │          │                   │                        │                                            │
│ ncurses-base │                │          │                   │                        │                                            │
│              │                │          │                   │                        │                                            │
├──────────────┤                │          │                   │                        │                                            │
│ ncurses-bin  │                │          │                   │                        │                                            │
│              │                │          │                   │                        │                                            │
└──────────────┴────────────────┴──────────┴───────────────────┴────────────────────────┴────────────────────────────────────────────┘
```

## new image

```
$ docker build . -t test-18
$ docker run --rm -v trivy-cache:/root/.cache/ -v /var/run/docker.sock:/var/run/docker.sock aquasec/trivy:latest image --exit-code 100 --no-progress --severity HIGH,CRITICAL --ignore-unfixed --skip-dirs /usr/local/lib/node_modules/npm --skip-files /app/agent.jar test-18
2023-05-10T13:57:35.251Z        INFO    Vulnerability scanning is enabled
2023-05-10T13:57:35.251Z        INFO    Secret scanning is enabled
2023-05-10T13:57:35.251Z        INFO    If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2023-05-10T13:57:35.251Z        INFO    Please see also https://aquasecurity.github.io/trivy/v0.41/docs/secret/scanning/#recommendation for faster secret detection
2023-05-10T13:57:35.263Z        INFO    Detected OS: debian
2023-05-10T13:57:35.263Z        INFO    Detecting Debian vulnerabilities...
2023-05-10T13:57:35.276Z        INFO    Number of language-specific files: 1
2023-05-10T13:57:35.276Z        INFO    Detecting node-pkg vulnerabilities...

test-16 (debian 11.7)
=====================
Total: 0 (HIGH: 0, CRITICAL: 0)
```