### PR TITLE
Feature/error handling

### DIFF
--- a/integration_tests/mockApis/person.ts
+++ b/integration_tests/mockApis/person.ts
@@ -1,4 +1,4 @@
-import type { OASysSections } from '@approved-premises/api'
+import type { OASysSections, Person } from '@approved-premises/api'
 import { stubFor } from '../../wiremock'
 
 export default {
@@ -12,6 +12,41 @@ export default {
         status: 200,
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
         jsonBody: args.oasysSections,
+      },
+    }),
+
+  stubFindPerson: (args: { person: Person }) =>
+    stubFor({
+      request: {
+        method: 'GET',
+        url: `/people/search?crn=${args.person.crn}`,
+      },
+      response: {
+        status: 201,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: args.person,
+      },
+    }),
+
+  stubPersonNotFound: (args: { person: Person }) =>
+    stubFor({
+      request: {
+        method: 'GET',
+        url: `/people/search?crn=${args.person.crn}`,
+      },
+      response: {
+        status: 404,
+      },
+    }),
+
+  stubFindPersonForbidden: (args: { person: Person }) =>
+    stubFor({
+      request: {
+        method: 'GET',
+        url: `/people/search?crn=${args.person.crn}`,
+      },
+      response: {
+        status: 403,
       },
     }),
 }

--- a/integration_tests/tests/risks/risks.cy.ts
+++ b/integration_tests/tests/risks/risks.cy.ts
@@ -1,7 +1,8 @@
 import IndexPage from '../../pages'
+import { personFactory } from '../../../server/testutils/factories/index'
 
 context('Risks', () => {
-  const crn = '1234'
+  const person = personFactory.build({})
 
   beforeEach(() => {
     cy.task('reset')
@@ -15,7 +16,7 @@ context('Risks', () => {
     // and there is Oasys data
     cy.fixture('oasysSections.json').then(riskData => {
       cy.task('stubOasysSections', {
-        crn,
+        crn: person.crn,
         oasysSections: riskData,
       })
     })
@@ -29,10 +30,66 @@ context('Risks', () => {
 
     // Then I see the CRN form
     // And enter a valid CRN
-    cy.get('#crn').type(crn)
+    cy.task('stubFindPerson', {
+      person,
+    })
+    cy.get('#crn').type(person.crn)
     cy.get('button').contains('Save and continue').click()
 
     // Then I see the risks for that person
     cy.get('[id^=roshAnswers]').contains('Some answer for the first RoSH question')
+  })
+
+  it('renders with an empty CRN error if the CRN is not entered', () => {
+    // Given I visit the start page
+    IndexPage.visit()
+    // And I click on the start button
+    cy.get('[role="button"]').click()
+
+    // Then I see the CRN form
+    // And I click submit without entering a CRN
+    cy.get('button').contains('Save and continue').click()
+
+    // Then I see an error message
+    cy.get('.govuk-error-summary').should('contain', `You must enter a CRN`)
+    cy.get(`[data-cy-error-crn]`).should('contain', `You must enter a CRN`)
+  })
+
+  it('renders with a CRN not found error if the API returns a 404', () => {
+    // Given I visit the start page
+    IndexPage.visit()
+    // And I click on the start button
+    cy.get('[role="button"]').click()
+
+    // Then I see the CRN form
+    // And enter a CRN
+    cy.task('stubPersonNotFound', {
+      person,
+    })
+    cy.get('#crn').type(person.crn)
+    cy.get('button').contains('Save and continue').click()
+
+    // Then I see an error message
+    cy.get('.govuk-error-summary').should('contain', `No person with a CRN of '${person.crn}' was found`)
+    cy.get(`[data-cy-error-crn]`).should('contain', `No person with a CRN of '${person.crn}' was found`)
+  })
+
+  it('renders with an authorisation error if the API returns a 403', () => {
+    // Given I visit the start page
+    IndexPage.visit()
+    // And I click on the start button
+    cy.get('[role="button"]').click()
+
+    // Then I see the CRN form
+    // And enter a valid CRN
+    cy.task('stubFindPersonForbidden', {
+      person,
+    })
+    cy.get('#crn').type(person.crn)
+    cy.get('button').contains('Save and continue').click()
+
+    // Then I see an error message
+    cy.get('.govuk-error-summary').should('contain', `You do not have permission to access this CRN`)
+    cy.get(`[data-cy-error-crn]`).should('contain', `You do not have permission to access this CRN`)
   })
 })

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -19,6 +19,7 @@ export declare global {
     interface Request {
       verified?: boolean
       id: string
+      flash(type: string, message: string | ErrorMessages | Array<ErrorSummary> | Record<string, unknown>): number
       logout(done: (err: unknown) => void): void
     }
   }

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -1,3 +1,26 @@
+export interface ErrorsAndUserInput {
+  errorTitle?: string
+  errors: ErrorMessages
+  errorSummary: Array<string>
+  userInput: Record<string, unknown>
+}
+
+export interface ErrorMessage {
+  text: string
+  attributes: {
+    [K: string]: boolean
+  }
+}
+export interface ErrorMessages {
+  [K: string]: ErrorMessage
+}
+
+export interface ErrorSummary {
+  text?: string
+  html?: string
+  href?: string
+}
+
 export type UserDetails = {
   id: string
   name: string

--- a/server/app.ts
+++ b/server/app.ts
@@ -1,6 +1,7 @@
 /* istanbul ignore file */
 
 import express from 'express'
+import flash from 'connect-flash'
 
 import path from 'path'
 import createError from 'http-errors'
@@ -41,6 +42,13 @@ export default function createApp(controllers: Controllers, services: Services):
   app.use(authorisationMiddleware())
   app.use(setUpCsrf())
   app.use(setUpCurrentUser(services))
+
+  app.use((req, res, next) => {
+    res.app.locals.infoMessages = req.flash('info')
+    res.app.locals.successMessages = req.flash('success')
+    return next()
+  })
+  app.use(flash())
 
   app.use(routes(controllers))
 

--- a/server/controllers/apply/applicationsController.test.ts
+++ b/server/controllers/apply/applicationsController.test.ts
@@ -1,9 +1,13 @@
 import type { NextFunction, Request, Response } from 'express'
 import { DeepMocked, createMock } from '@golevelup/ts-jest'
 import { OASysSections } from '@approved-premises/api'
+import { ErrorsAndUserInput } from '@approved-premises/ui'
 
+import { fetchErrorsAndUserInput } from '../../utils/validation'
 import ApplicationsController from './applicationsController'
 import { PersonService } from '../../services'
+
+jest.mock('../../utils/validation')
 
 describe('applicationsController', () => {
   const token = 'SOME_TOKEN'
@@ -25,10 +29,33 @@ describe('applicationsController', () => {
 
   describe('new', () => {
     it('renders the crn form', () => {
+      ;(fetchErrorsAndUserInput as jest.Mock).mockImplementation(() => {
+        return { errors: {}, errorSummary: [], userInput: {} }
+      })
+
       const requestHandler = applicationsController.new()
+
       requestHandler(request, response, next)
+
       expect(response.render).toHaveBeenCalledWith('applications/new', {
         pageHeading: "Enter the person's CRN",
+        errors: {},
+        errorSummary: [],
+      })
+    })
+
+    it('renders the form with errors and user input if an error has been sent to the flash', async () => {
+      const errorsAndUserInput = createMock<ErrorsAndUserInput>()
+      ;(fetchErrorsAndUserInput as jest.Mock).mockReturnValue(errorsAndUserInput)
+
+      const requestHandler = applicationsController.new()
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('applications/new', {
+        pageHeading: "Enter the person's CRN",
+        errors: errorsAndUserInput.errors,
+        errorSummary: errorsAndUserInput.errorSummary,
+        ...errorsAndUserInput.userInput,
       })
     })
   })

--- a/server/controllers/apply/applicationsController.ts
+++ b/server/controllers/apply/applicationsController.ts
@@ -1,13 +1,18 @@
 import { OASysSections } from '@approved-premises/api'
 import { Request, RequestHandler, Response } from 'express'
 import PersonService from '../../services/personService'
+import { fetchErrorsAndUserInput } from '../../utils/validation'
 
 export default class ApplicationsController {
   constructor(private readonly personService: PersonService) {}
 
   new(): RequestHandler {
     return async (req: Request, res: Response) => {
+      const { errors, errorSummary, userInput } = fetchErrorsAndUserInput(req)
       return res.render('applications/new', {
+        errors,
+        errorSummary,
+        ...userInput,
         pageHeading: "Enter the person's CRN",
       })
     }

--- a/server/controllers/index.ts
+++ b/server/controllers/index.ts
@@ -2,11 +2,11 @@
 
 import { controllers as applyControllers } from './apply'
 
-import type { Services } from '../services'
+import { Services } from '../services'
 import PeopleController from './peopleController'
 
 export const controllers = (services: Services) => {
-  const peopleController = new PeopleController()
+  const peopleController = new PeopleController(services.personService)
   return {
     peopleController,
     ...applyControllers(services),

--- a/server/controllers/peopleController.ts
+++ b/server/controllers/peopleController.ts
@@ -1,17 +1,43 @@
 import type { Request, RequestHandler, Response } from 'express'
 import paths from '../paths/apply'
+import { errorMessage, errorSummary } from '../utils/validation'
+import PersonService from '../services/personService'
 
 export default class PeopleController {
+  constructor(private readonly personService: PersonService) {}
+
   find(): RequestHandler {
     return async (req: Request, res: Response) => {
       const { crn } = req.body
 
       if (crn) {
-        // TODO: error handling if invalid/not found CRN
-        res.redirect(paths.applications.show({ crn }))
+        try {
+          await this.personService.findByCrn(req.user.token, crn)
+
+          res.redirect(paths.applications.show({ crn }))
+        } catch (err) {
+          if (err.status === 404) {
+            this.addErrorMessagesToFlash(req, `No person with a CRN of '${crn}' was found`)
+          } else if (err.status === 403) {
+            this.addErrorMessagesToFlash(req, 'You do not have permission to access this CRN')
+          } else {
+            throw err
+          }
+
+          res.redirect(req.headers.referer)
+        }
       } else {
-        res.redirect(req.headers.referer || '')
+        this.addErrorMessagesToFlash(req, 'You must enter a CRN')
+        res.redirect(req.headers.referer)
       }
     }
+  }
+
+  addErrorMessagesToFlash(request: Request, message: string) {
+    request.flash('errors', {
+      crn: errorMessage('crn', message),
+    })
+    request.flash('errorSummary', [errorSummary('crn', message)])
+    request.flash('userInput', request.body)
   }
 }

--- a/server/data/personClient.test.ts
+++ b/server/data/personClient.test.ts
@@ -1,5 +1,5 @@
 import PersonClient from './personClient'
-import { oasysSectionsFactory } from '../testutils/factories'
+import { oasysSectionsFactory, personFactory } from '../testutils/factories'
 import paths from '../paths/api'
 
 import describeClient from '../testutils/describeClient'
@@ -66,6 +66,35 @@ describeClient('PersonClient', provider => {
       const result = await personClient.oasysSections(crn)
 
       expect(result).toEqual(oasysSections)
+    })
+  })
+
+  describe('search', () => {
+    it('should return a person', async () => {
+      const person = personFactory.build()
+
+      provider.addInteraction({
+        state: 'Server is healthy',
+        uponReceiving: 'A request to search for a person',
+        withRequest: {
+          method: 'GET',
+          path: `/people/search`,
+          query: {
+            crn: 'crn',
+          },
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+        },
+        willRespondWith: {
+          status: 200,
+          body: person,
+        },
+      })
+
+      const result = await personClient.search('crn')
+
+      expect(result).toEqual(person)
     })
   })
 })

--- a/server/data/personClient.ts
+++ b/server/data/personClient.ts
@@ -1,4 +1,4 @@
-import type { OASysSections } from '@approved-premises/api'
+import type { OASysSections, Person } from '@approved-premises/api'
 
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
@@ -20,5 +20,16 @@ export default class PersonClient {
     const response = (await this.restClient.get({ path })) as OASysSections
 
     return response
+  }
+
+  async search(crn: string): Promise<Person> {
+    const query = { crn } as Record<string, string | boolean>
+
+    const path = `${paths.people.search({})}?${createQueryString(query)}`
+    const response = await this.restClient.get({
+      path,
+    })
+
+    return response as Person
   }
 }

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -9,5 +9,6 @@ export default {
     oasys: {
       sections: oasysPath.path('sections'),
     },
+    search: peoplePath.path('search'),
   },
 }

--- a/server/services/personService.test.ts
+++ b/server/services/personService.test.ts
@@ -1,4 +1,4 @@
-import { oasysSectionsFactory } from '../testutils/factories'
+import { oasysSectionsFactory, personFactory } from '../testutils/factories'
 import PersonService from './personService'
 import { PersonClient } from '../data'
 
@@ -28,6 +28,20 @@ describe('Person Service', () => {
       expect(serviceOasysSections).toEqual(oasysSections)
       expect(personClientFactory).toHaveBeenCalledWith(token)
       expect(personClient.oasysSections).toHaveBeenCalledWith('crn', [])
+    })
+  })
+
+  describe('findByCrn', () => {
+    it('on success returns the person given their CRN', async () => {
+      const person = personFactory.build()
+      personClient.search.mockResolvedValue(person)
+
+      const postedPerson = await service.findByCrn(token, 'crn')
+
+      expect(postedPerson).toEqual(person)
+
+      expect(personClientFactory).toHaveBeenCalledWith(token)
+      expect(personClient.search).toHaveBeenCalledWith('crn')
     })
   })
 })

--- a/server/services/personService.ts
+++ b/server/services/personService.ts
@@ -1,4 +1,4 @@
-import type { OASysSections } from '@approved-premises/api'
+import type { OASysSections, Person } from '@approved-premises/api'
 import type { PersonClient, RestClientBuilder } from '../data'
 
 export default class PersonService {
@@ -10,5 +10,12 @@ export default class PersonService {
     const oasysSections = await personClient.oasysSections(crn, selectedSections)
 
     return oasysSections
+  }
+
+  async findByCrn(token: string, crn: string): Promise<Person> {
+    const personClient = this.personClientFactory(token)
+
+    const person = await personClient.search(crn)
+    return person
   }
 }

--- a/server/testutils/factories/index.ts
+++ b/server/testutils/factories/index.ts
@@ -1,4 +1,5 @@
 import oasysSectionsFactory, { roshSummaryFactory } from './oasysSections'
 import oasysSelectionFactory from './oasysSelection'
+import personFactory from './person'
 
-export { oasysSectionsFactory, oasysSelectionFactory, roshSummaryFactory }
+export { oasysSectionsFactory, oasysSelectionFactory, roshSummaryFactory, personFactory }

--- a/server/testutils/factories/person.ts
+++ b/server/testutils/factories/person.ts
@@ -1,0 +1,17 @@
+import { Factory } from 'fishery'
+import { faker } from '@faker-js/faker/locale/en_GB'
+
+import type { Person } from '@approved-premises/api'
+import { DateFormats } from '../../utils/dateUtils'
+
+export default Factory.define<Person>(() => ({
+  crn: `C${faker.number.int({ min: 100000, max: 999999 })}`,
+  name: faker.person.fullName(),
+  dateOfBirth: DateFormats.dateObjToIsoDate(faker.date.past()),
+  sex: faker.helpers.arrayElement(['Male', 'Female', 'Other', 'Prefer not to say']),
+  status: faker.helpers.arrayElement(['InCustody', 'InCommunity']),
+  nomsNumber: `NOMS${faker.number.int({ min: 100, max: 999 })}`,
+  nationality: faker.location.country(),
+  religionOrBelief: faker.helpers.arrayElement(['Christian', 'Muslim', 'Jewish', 'Hindu', 'Buddhist', 'Sikh', 'None']),
+  prisonName: `HMP ${faker.location.street()}`,
+}))

--- a/server/utils/validation.test.ts
+++ b/server/utils/validation.test.ts
@@ -1,0 +1,42 @@
+import { Request } from 'express'
+import { createMock } from '@golevelup/ts-jest'
+import type { ErrorMessages, ErrorSummary } from '@approved-premises/ui'
+
+import { fetchErrorsAndUserInput } from './validation'
+
+describe('fetchErrorsAndUserInput', () => {
+  const request = createMock<Request>({})
+
+  let errors: ErrorMessages
+  let userInput: Record<string, unknown>
+  let errorSummary: ErrorSummary
+  let errorTitle: string
+
+  beforeEach(() => {
+    ;(request.flash as jest.Mock).mockImplementation((message: string) => {
+      return {
+        errors: [errors],
+        userInput: [userInput],
+        errorSummary,
+        errorTitle: [errorTitle],
+      }[message]
+    })
+  })
+
+  it('returns default values if there is nothing present', () => {
+    const result = fetchErrorsAndUserInput(request)
+
+    expect(result).toEqual({ errors: {}, errorSummary: [], userInput: {}, errorTitle: undefined })
+  })
+
+  it('fetches the values from the flash', () => {
+    errors = createMock<ErrorMessages>()
+    errorSummary = createMock<ErrorSummary>()
+    userInput = { foo: 'bar' }
+    errorTitle = 'Some title'
+
+    const result = fetchErrorsAndUserInput(request)
+
+    expect(result).toEqual({ errors, errorSummary, userInput, errorTitle })
+  })
+})

--- a/server/utils/validation.ts
+++ b/server/utils/validation.ts
@@ -1,0 +1,32 @@
+import type { Request } from 'express'
+import { ErrorsAndUserInput, ErrorMessage, ErrorSummary } from '@approved-premises/ui'
+
+const firstFlashItem = (request: Request, key: string) => {
+  const message = request.flash(key)
+  return message ? message[0] : undefined
+}
+
+export const fetchErrorsAndUserInput = (request: Request): ErrorsAndUserInput => {
+  const errors = firstFlashItem(request, 'errors') || {}
+  const errorSummary = request.flash('errorSummary') || []
+  const userInput = firstFlashItem(request, 'userInput') || {}
+  const errorTitle = firstFlashItem(request, 'errorTitle')
+
+  return { errors, errorTitle, errorSummary, userInput }
+}
+
+export const errorMessage = (field: string, text: string): ErrorMessage => {
+  return {
+    text,
+    attributes: {
+      [`data-cy-error-${field}`]: true,
+    },
+  }
+}
+
+export const errorSummary = (field: string, text: string): ErrorSummary => {
+  return {
+    text,
+    href: `#${field}`,
+  }
+}

--- a/server/views/applications/new.njk
+++ b/server/views/applications/new.njk
@@ -1,6 +1,7 @@
 {%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "../partials/showErrorSummary.njk" import showErrorSummary %}
 {% from "../components/formFields/form-page-input/macro.njk" import formPageInput %}
 
 {% extends "../partials/layout.njk" %}
@@ -14,6 +15,8 @@
     <div class="govuk-grid-column-two-thirds">
       <form action="{{ paths.applications.people.find() }}" method="post">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+
+        {{ showErrorSummary(errorSummary) }}
 
         {{
           formPageInput(

--- a/server/views/partials/showErrorSummary.njk
+++ b/server/views/partials/showErrorSummary.njk
@@ -1,0 +1,12 @@
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+
+{% macro showErrorSummary(errorList, errorTitle) %}
+
+  {% if errorList | length %}
+    {{ govukErrorSummary({
+      titleText: errorTitle if errorTitle else "There is a problem",
+      errorList: errorList
+    }) }}
+  {% endif %}
+
+{% endmacro %}


### PR DESCRIPTION
## Summary of changes

This PR adds error handling for the CRN search feature, so that users will be notified if they do not enter a CRN, or enter a CRN that does not exist, or that they are not authorised to access. Any other error will be thrown and handled generically.

A lot of the code outside the peopleController has been copied over from CAS-1 with some minor modifications (e.g. removing unnecessary function parameters).

## Screenshots

![Screenshot 2023-05-23 at 10 40 59](https://github.com/ministryofjustice/hmpps-supported-accommodation-ui/assets/70749355/c592b579-6268-4346-b58f-04b75d1ca2eb)

![Screenshot 2023-05-23 at 11 20 12](https://github.com/ministryofjustice/hmpps-supported-accommodation-ui/assets/70749355/9bfc3da0-c57c-40e7-a4ab-eec34f493093)

